### PR TITLE
Refine test script to fetch recent Toronto internships

### DIFF
--- a/test.py
+++ b/test.py
@@ -3,12 +3,17 @@ from jobspy import scrape_jobs
 
 jobs = scrape_jobs(
     site_name=["indeed", "linkedin", "zip_recruiter", "glassdoor", "google"],
-    search_term="software engineer",
-    google_search_term="software engineer jobs near San Francisco, CA since yesterday",
-    location="San Francisco, CA",
+    search_term="software engineer intern",
+    google_search_term="software engineer intern jobs near Toronto, Ontario since yesterday",
+    # Glassdoor's location API rejects province abbreviations; provide the full
+    # region and country to avoid a 400 "location not parsed" response.
+    location="Toronto, Ontario, Canada",
+    job_type="internship",
     results_wanted=20,
-    hours_old=72,
-    country_indeed="USA"
+    hours_old=24,
+    # Explicitly pass the country so Indeed/Glassdoor map to the correct domains
+    # (e.g. glassdoor.ca) and ZipRecruiter recognises the search region.
+    country_indeed="Canada",
 )
 print(f"Found {len(jobs)} jobs")
 jobs.to_csv("job1.csv", quoting=csv.QUOTE_NONNUMERIC, escapechar="\\", index=False)


### PR DESCRIPTION
## Summary
- update test script to query software engineer internships in Toronto posted in the last day
- ensure full location and country are supplied so Glassdoor and ZipRecruiter use the correct regional endpoints

## Testing
- `pre-commit run --files test.py`
- `pytest` *(fails: TLSClientExeption: failed to do request: Post "https://api.ziprecruiter.com/jobs-app/event": dial tcp 104.16.162.111:443: connect: network is unreachable)*
- `python test.py` *(fails: ProxyError: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a290f2e29c83278bd6d1922a0b5d73